### PR TITLE
Use proper WUMA function

### DIFF
--- a/lua/autorun/sh_custom_loadout.lua
+++ b/lua/autorun/sh_custom_loadout.lua
@@ -19,8 +19,8 @@ function CLoadout:IsBlacklisted( ply, class )
 	end
 
 	-- WUMA compatibility
-	if WUMA and WUMA.HasRestriction then
-		return WUMA.HasRestriction( ply:GetUserGroup(), 'swep', class )
+	if WUMA then
+		return ply:CheckRestriction( 'swep', class )
 	end
 
 	return false


### PR DESCRIPTION
The current wuma function causes insane lag spikes on spawnins.
![image](https://user-images.githubusercontent.com/69946827/211091432-5787dc61-0747-4500-995e-db3f121fd2af.png)

Wuma uses this function it defined itself: https://github.com/Weol/wuma/blob/60ae84e7eaca68f1b1113d9867882a3bed9c4401/lua/wuma/hooks.lua#L127

Tested this change and it works.