### PR TITLE
Change init hook for reliability with Linux clients

### DIFF
--- a/lua/custom_loadout/cl_main.lua
+++ b/lua/custom_loadout/cl_main.lua
@@ -226,9 +226,10 @@ function CLoadout:Load()
 end
 
 -- late init (to make sure all weapons have been registered)
-hook.Add( "SetupMove", "CLoadout_Initialize", function()
-    CLoadout:Init()
-    hook.Remove( "SetupMove", "CLoadout_Initialize" )
+local initHook = game.SinglePlayer() and "InitPostEntity" or "SetupMove"
+hook.Add( initHook, "CLoadout_Initialize", function()
+    timer.Simple(1, function() CLoadout:Init() end)
+    hook.Remove( initHook, "CLoadout_Initialize" )
 end )
 
 hook.Add( "OnPlayerChat", "CLoadout_ChatCommand", function( ply, text )

--- a/lua/custom_loadout/cl_main.lua
+++ b/lua/custom_loadout/cl_main.lua
@@ -226,10 +226,16 @@ function CLoadout:Load()
 end
 
 -- late init (to make sure all weapons have been registered)
+-- linux clients do not run InitPostEntity on servers
 local initHook = game.SinglePlayer() and "InitPostEntity" or "SetupMove"
 hook.Add( initHook, "CLoadout_Initialize", function()
-    timer.Simple(1, function() CLoadout:Init() end)
     hook.Remove( initHook, "CLoadout_Initialize" )
+    if CLoadout.initialized then return end
+
+    timer.Simple( 0, function()
+        CLoadout.initialized = true
+        CLoadout:Init()
+    end )
 end )
 
 hook.Add( "OnPlayerChat", "CLoadout_ChatCommand", function( ply, text )

--- a/lua/custom_loadout/cl_main.lua
+++ b/lua/custom_loadout/cl_main.lua
@@ -226,12 +226,9 @@ function CLoadout:Load()
 end
 
 -- late init (to make sure all weapons have been registered)
-hook.Add( "InitPostEntity", "CLoadout_Initialize", function()
-    hook.Remove( "InitPostEntity", "CLoadout_Initialize" )
-
-    -- on rare occasions it just didnt work
-    -- if called right at InitPostEntity
-    timer.Simple( 1, function() CLoadout:Init() end )
+hook.Add( "SetupMove", "CLoadout_Initialize", function()
+    CLoadout:Init()
+    hook.Remove( "SetupMove", "CLoadout_Initialize" )
 end )
 
 hook.Add( "OnPlayerChat", "CLoadout_ChatCommand", function( ply, text )


### PR DESCRIPTION
The current implementation for the init function seems to always fail for Linux users on dedicated servers. Strangely this doesn't apply to singleplayer.

Using `SetupMove` as an alternative (as it only starts calling when the player is able to move) seems to work, but because it's predicted we still need to use `InitPostEntity` in singleplayer.