### PR TITLE
"Other" SWEPs will now always be in the proper Other category

### DIFF
--- a/lua/custom_loadout/cl_main.lua
+++ b/lua/custom_loadout/cl_main.lua
@@ -13,6 +13,11 @@ function CLoadout:InitRegistry()
 
         categories[cat] = true
 
+        if cat == "Other" then
+            cat = "#spawnmenu.category.other"
+        end
+
+
         registry[v.ClassName] = {
             adminOnly = v.AdminOnly,
             name = ( v.PrintName and v.PrintName ~= "" ) and v.PrintName or v.ClassName,


### PR DESCRIPTION
Some SWEPs. despite setting the Category string as "Other", will not get the localized Other category but a separate(!) Other category. That also happens in English for some reason, so you have 2 Other categories.

An example of this is a Bottle SWEP from one of my addons. https://steamcommunity.com/sharedfiles/filedetails/?id=3275841807 Works just fine in the spawnmenu, but not in the loadout mod on my end. My Rosary is also affected, but not my Bible mods, despite the fact all of them set Category as plain string "Other".

I have a feeling this has to do with the load order of the mods, but I'm not fully confident in that. Either way, this fixes it for all localization.